### PR TITLE
Add pressRepeat  to get stepper after autoRepeatInterval

### DIFF
--- a/Source/KWStepper+Chaining.swift
+++ b/Source/KWStepper+Chaining.swift
@@ -6,121 +6,121 @@
 
 extension KWStepper {
     // MARK: - Configuration Methods
-
+    
     /// Sets the stepper's `autoRepeat` value.
     @discardableResult
     public func autoRepeat(_ value: Bool) -> Self {
         autoRepeat = value
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `autoRepeatInterval`.
     @discardableResult
     public func autoRepeatInterval(_ value: TimeInterval) -> Self {
         autoRepeatInterval = value
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `wraps` value.
     @discardableResult
     public func wraps(_ value: Bool) -> Self {
         wraps = value
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `minimumValue`.
     @discardableResult
     public func minimumValue(_ value: Double) -> Self {
         minimumValue = value
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `maximumValue`.
     @discardableResult
     public func maximumValue(_ value: Double) -> Self {
         maximumValue = value
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `decrementStepValue`.
     @discardableResult
     public func decrementStepValue(_ value: Double) -> Self {
         decrementStepValue = value
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `incrementStepValue`.
     @discardableResult
     public func incrementStepValue(_ value: Double) -> Self {
         incrementStepValue = value
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `roundingBehavior`.
     @discardableResult
     public func roundingBehavior(_ value: Double) -> Self {
         self.roundingBehavior = roundingBehavior
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `delegate`.
     @discardableResult
     public func delegate(_ value: KWStepperDelegate?) -> Self {
         delegate = value
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `value`.
     @discardableResult
     public func value(_ value: Double) -> Self {
         self.value = value
-
+        
         return self
     }
-
+    
     // MARK: - Callback Methods
-
+    
     /// Sets the stepper's `valueChangedCallback`.
     @discardableResult
     public func valueChanged(_ callback: KWStepperCallback?) -> Self {
         valueChangedCallback = callback
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `decrementCallback`.
     @discardableResult
     public func didDecrement(_ callback: KWStepperCallback?) -> Self {
         decrementCallback = callback
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `incrementCallback`.
     @discardableResult
     public func didIncrement(_ callback: KWStepperCallback?) -> Self {
         incrementCallback = callback
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `maxValueClampedCallback`.
     @discardableResult
     public func maxValueClamped(_ callback: KWStepperCallback?) -> Self {
         maxValueClampedCallback = callback
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `minValueClampedCallback`.
     @discardableResult
     public func minValueClamped(_ callback: KWStepperCallback?) -> Self {
@@ -128,24 +128,32 @@ extension KWStepper {
         
         return self
     }
-
+    
     // MARK: - Convenience Methods
-
+    
     /// Sets the stepper's `decrementStepValue` and `incrementStepValue`.
     @discardableResult
     public func stepValue(_ value: Double) -> Self {
         decrementStepValue = value
         incrementStepValue = value
-
+        
         return self
     }
-
+    
     /// Sets the stepper's `maxValueClampedCallback` and `minValueClampedCallback`.
     @discardableResult
     public func valueClamped(_ callback: @escaping KWStepperCallback) -> Self {
         maxValueClampedCallback = callback
         minValueClampedCallback = callback
-
+        
+        return self
+    }
+    
+    /// Sets the stepper's `pressRepeatCallback`.
+    @discardableResult
+    public func pressRepeat(_ callback: KWStepperCallback?) -> Self {
+        pressRepeatCallback = callback
+        
         return self
     }
 }

--- a/Source/KWStepper+Chaining.swift
+++ b/Source/KWStepper+Chaining.swift
@@ -151,7 +151,7 @@ extension KWStepper {
     
     /// Sets the stepper's `pressRepeatCallback`.
     @discardableResult
-    public func pressRepeat(_ callback: KWStepperCallback?) -> Self {
+    public func pressRepeat(_ callback: @escaping ((KWStepper,Bool) -> Void)) -> Self {
         pressRepeatCallback = callback
         
         return self

--- a/Source/KWStepper+Chaining.swift
+++ b/Source/KWStepper+Chaining.swift
@@ -151,7 +151,7 @@ extension KWStepper {
     
     /// Sets the stepper's `pressRepeatCallback`.
     @discardableResult
-    public func pressRepeat(_ callback: @escaping ((KWStepper,Bool) -> Void)) -> Self {
+    public func pressRepeat(_ callback: @escaping KWStepperCallback) -> Self {
         pressRepeatCallback = callback
         
         return self

--- a/Source/KWStepper.swift
+++ b/Source/KWStepper.swift
@@ -151,7 +151,7 @@ public class KWStepper: UIControl {
     public var minValueClampedCallback: KWStepperCallback?
     
     /// Executed when period of press ends
-    public var pressRepeatCallback: KWStepperCallback?
+    public var pressRepeatCallback: ((KWStepper,Bool) -> Void)?
     
     
     // MARK: - Private Variables
@@ -206,13 +206,13 @@ public class KWStepper: UIControl {
         // The `value` should wrap to `maximumValue`.
         if wraps && decrementedValue < minimumValue {
             value = maximumValue
-            startPressTimer()
+            startPressTimer(isIncrementChange: false)
             // The `value` should be decremented.
         } else if decrementedValue >= minimumValue {
             value = decrementedValue
             delegate?.KWStepperDidDecrement?()
             decrementCallback?(self)
-            startPressTimer()
+            startPressTimer(isIncrementChange: false)
             // The `value` should be clamped.
         } else {
             endLongPress()
@@ -232,13 +232,13 @@ public class KWStepper: UIControl {
         // The `value` should wrap to `minimumValue`.
         if wraps && incrementedValue > maximumValue {
             value = minimumValue
-            startPressTimer()
+            startPressTimer(isIncrementChange: true)
             // The `value` should be incremented.
         } else if incrementedValue <= maximumValue {
             value = incrementedValue
             delegate?.KWStepperDidIncrement?()
             incrementCallback?(self)
-            startPressTimer()
+            startPressTimer(isIncrementChange: true)
             // The `value` should be clamped.
         } else {
             endLongPress()
@@ -250,20 +250,20 @@ public class KWStepper: UIControl {
     }
     
     // start timer to get the stepper after 'autoRepeatInterval'
-    func startPressTimer(){
-        if pressRepeat && pressTimer == nil {
+    func startPressTimer(isIncrementChange:Bool){
+        if pressRepeat {
             pressTimer = Timer.scheduledTimer(
                 timeInterval: pressRepeatInterval,
                 target: self,
                 selector:  #selector(pressTimerAction),
-                userInfo: nil,
+                userInfo: isIncrementChange,
                 repeats: true
             )
         }
     }
     
     func pressTimerAction(){
-        pressRepeatCallback?(self)
+        pressRepeatCallback?(self,pressTimer?.userInfo as? Bool == true)
         pressTimer?.invalidate()
         pressTimer = nil
     }

--- a/Source/KWStepper.swift
+++ b/Source/KWStepper.swift
@@ -151,7 +151,7 @@ public class KWStepper: UIControl {
     public var minValueClampedCallback: KWStepperCallback?
     
     /// Executed when period of press ends
-    public var pressRepeatCallback: ((KWStepper,Bool) -> Void)?
+    public var pressRepeatCallback: KWStepperCallback?
     
     
     // MARK: - Private Variables
@@ -206,13 +206,13 @@ public class KWStepper: UIControl {
         // The `value` should wrap to `maximumValue`.
         if wraps && decrementedValue < minimumValue {
             value = maximumValue
-            startPressTimer(isIncrementChange: false)
+            startPressTimer()
             // The `value` should be decremented.
         } else if decrementedValue >= minimumValue {
             value = decrementedValue
             delegate?.KWStepperDidDecrement?()
             decrementCallback?(self)
-            startPressTimer(isIncrementChange: false)
+            startPressTimer()
             // The `value` should be clamped.
         } else {
             endLongPress()
@@ -232,13 +232,13 @@ public class KWStepper: UIControl {
         // The `value` should wrap to `minimumValue`.
         if wraps && incrementedValue > maximumValue {
             value = minimumValue
-            startPressTimer(isIncrementChange: true)
+            startPressTimer()
             // The `value` should be incremented.
         } else if incrementedValue <= maximumValue {
             value = incrementedValue
             delegate?.KWStepperDidIncrement?()
             incrementCallback?(self)
-            startPressTimer(isIncrementChange: true)
+            startPressTimer()
             // The `value` should be clamped.
         } else {
             endLongPress()
@@ -250,22 +250,22 @@ public class KWStepper: UIControl {
     }
     
     // start timer to get the stepper after 'autoRepeatInterval'
-    func startPressTimer(isIncrementChange:Bool){
+    func startPressTimer(){
         if pressRepeat {
             pressTimer = Timer.scheduledTimer(
                 timeInterval: pressRepeatInterval,
                 target: self,
                 selector:  #selector(pressTimerAction),
-                userInfo: isIncrementChange,
-                repeats: true
+                userInfo: nil,
+                repeats: false
             )
         }
     }
     
     func pressTimerAction(){
-        pressRepeatCallback?(self,pressTimer?.userInfo as? Bool == true)
         pressTimer?.invalidate()
         pressTimer = nil
+        pressRepeatCallback?(self)
     }
     
 }

--- a/Source/KWStepper.swift
+++ b/Source/KWStepper.swift
@@ -128,6 +128,9 @@ public class KWStepper: UIControl {
             
             sendActions(for: .valueChanged)
             valueChangedCallback?(self)
+            
+            //call press timer on increment
+            startPressTimer()
         }
     }
     
@@ -218,8 +221,6 @@ public class KWStepper: UIControl {
             minValueClampedCallback?(self)
         }
         
-        //call press timer on decrement
-        startPressTimer()
         return self
     }
     
@@ -243,8 +244,7 @@ public class KWStepper: UIControl {
             delegate?.KWStepperMaxValueClamped?()
             maxValueClampedCallback?(self)
         }
-        //call press timer on increment
-        startPressTimer()
+        
         return self
     }
     

--- a/Source/KWStepper.swift
+++ b/Source/KWStepper.swift
@@ -11,13 +11,13 @@ import UIKit
 @objc public protocol KWStepperDelegate {
     /// Called when `value` is decremented; not when `value` is clamped or wrapped.
     @objc optional func KWStepperDidDecrement()
-
+    
     /// Called when `value` is incremented; not when `value` is clamped or wrapped.
     @objc optional func KWStepperDidIncrement()
-
+    
     /// Called when `value` is clamped to `maximumValue` via `incrementValue()`.
     @objc optional func KWStepperMaxValueClamped()
-
+    
     /// Called when `value` is clamped to `minimumValue` via `decrementValue()`.
     @objc optional func KWStepperMinValueClamped()
 }
@@ -26,7 +26,7 @@ import UIKit
 
 public class KWStepper: UIControl {
     // MARK: - Configuring the Stepper
-
+    
     /// If true, long pressing repeatedly alters `value`. Default = true.
     public var autoRepeat = true {
         didSet {
@@ -35,7 +35,17 @@ public class KWStepper: UIControl {
             }
         }
     }
-
+    
+    /// If true, pressRepeatCallback called after 'autoRepeatInterval' and stepper kept his value. Default = true.
+    public var pressRepeat = true {
+        didSet {
+            if pressRepeatInterval <= 0 {
+                pressRepeat = false
+            }
+        }
+    }
+    
+    
     /// The interval at which `autoRepeat` changes the stepper value, specified in seconds. Default = 0.10.
     public var autoRepeatInterval: TimeInterval = 0.10 {
         didSet {
@@ -45,42 +55,52 @@ public class KWStepper: UIControl {
             }
         }
     }
-
+    
+    /// The interval at which `pressRepeat` changes the stepper value, specified in seconds. Default = 0.10.
+    public var pressRepeatInterval: TimeInterval = 0.10 {
+        didSet {
+            if pressRepeatInterval <= 0 {
+                pressRepeatInterval = 0.10
+                pressRepeat = false
+            }
+        }
+    }
+    
     /**
      If true, `value` wraps from `minimumValue` <-> `maximumValue`. Default = false.
      The expected result of a wrapped `value` is the opposite limit–regardless of the
      `decrementStepValue` or `incrementStepValue`. `UIStepper` exhibits the same behavior.
-    */
+     */
     public var wraps = false
-
+    
     /// The minimum value. Must be less than `maximumValue`. Default = 0.
     public var minimumValue = 0.0 {
         willSet {
             assert(newValue < maximumValue, "\(type(of: self)): minimumValue must be less than maximumValue.")
         }
     }
-
+    
     /// The maximum value. Must be greater than `minimumValue`. Default = 100.
     public var maximumValue = 100.0 {
         willSet {
             assert(newValue > minimumValue, "\(type(of: self)): maximumValue must be greater than minimumValue.")
         }
     }
-
+    
     /// The value to step when decrementing. Must be greater than 0. Default = 1.
     public var decrementStepValue = 1.0 {
         willSet {
             assert(newValue > 0, "\(type(of: self)): decrementStepValue must be greater than zero.")
         }
     }
-
+    
     /// The value to step when incrementing. Must be greater than 0. Default = 1.
     public var incrementStepValue = 1.0 {
         willSet {
             assert(newValue > 0, "\(type(of: self)): incrementStepValue must be greater than zero.")
         }
     }
-
+    
     /// Determines the rounding behavior used when incrementing or decrementing.
     public var roundingBehavior = NSDecimalNumberHandler(
         roundingMode: .bankers,
@@ -89,62 +109,68 @@ public class KWStepper: UIControl {
         raiseOnOverflow: false,
         raiseOnUnderflow: false,
         raiseOnDivideByZero: true)
-
+    
     /// The delegate for the control.
     public weak var delegate: KWStepperDelegate?
-
+    
     // MARK: - Accessing the Stepper’s Value
-
+    
     /// The stepper value. Default = 0.
     public var value = 0.0 {
         didSet {
             guard value != oldValue else { return }
-
+            
             if value < minimumValue {
                 value = minimumValue
             } else if value > maximumValue {
                 value = maximumValue
             }
-
+            
             sendActions(for: .valueChanged)
             valueChangedCallback?(self)
         }
     }
-
+    
     // MARK: - Callbacks
-
+    
     public typealias KWStepperCallback = ((KWStepper) -> Void)
-
+    
     /// Executed when `value` is changed; not when `value == oldValue`.
     public var valueChangedCallback: KWStepperCallback?
-
+    
     /// Executed when `value` is decremented; not when `value` is clamped or wrapped.
     public var decrementCallback: KWStepperCallback?
-
+    
     /// Executed when `value` is incremented; not when `value` is clamped or wrapped.
     public var incrementCallback: KWStepperCallback?
-
+    
     /// Executed when `value` is clamped to `maximumValue` via `incrementValue()`.
     public var maxValueClampedCallback: KWStepperCallback?
-
+    
     /// Executed when `value` is clamped to `minimumValue` via `decrementValue()`.
     public var minValueClampedCallback: KWStepperCallback?
-
+    
+    /// Executed when period of press ends
+    public var pressRepeatCallback: KWStepperCallback?
+    
+    
     // MARK: - Private Variables
-
+    
     fileprivate var longPressTimer: Timer?
-
+    fileprivate var pressTimer: Timer?
+    
+    
     // MARK: - Initialization
-
+    
     /// A `UIButton` that decrements `value` when pressed.
     public let decrementButton: UIButton
-
+    
     /// A `UIButton` that increments `value` when pressed.
     public let incrementButton: UIButton
-
+    
     /**
      Initializes a `KWStepper` instance with the provided buttons.
-
+     
      - Parameters:
      - decrementButton: The button used to decrement the `value`
      - incrementButton: The button used to increment the `value`
@@ -152,70 +178,95 @@ public class KWStepper: UIControl {
     public init(decrementButton: UIButton, incrementButton: UIButton) {
         self.decrementButton = decrementButton
         self.incrementButton = incrementButton
-
+        
         super.init(frame: .zero)
-
+        
         self.decrementButton.addTarget(self, action: #selector(decrementValue), for: .touchUpInside)
         self.incrementButton.addTarget(self, action: #selector(incrementValue), for: .touchUpInside)
-
+        
         for button in [self.decrementButton, self.incrementButton] {
             let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(_:)))
             button.addGestureRecognizer(longPressRecognizer)
         }
     }
-
+    
     /// :nodoc:
     required public init?(coder aDecoder: NSCoder) {
         fatalError("KWStepper: NSCoding is not supported!")
     }
-
+    
     // MARK: - Decrementing & Incrementing
-
+    
     /// Decrements the stepper `value` by `decrementStepValue`.
     @discardableResult
     public func decrementValue() -> Self {
+        
         let decrementedValue = (value - decrementStepValue).round(with: roundingBehavior)
-
+        
         // The `value` should wrap to `maximumValue`.
         if wraps && decrementedValue < minimumValue {
             value = maximumValue
-        // The `value` should be decremented.
+            // The `value` should be decremented.
         } else if decrementedValue >= minimumValue {
             value = decrementedValue
             delegate?.KWStepperDidDecrement?()
             decrementCallback?(self)
-        // The `value` should be clamped.
+            // The `value` should be clamped.
         } else {
             endLongPress()
             delegate?.KWStepperMinValueClamped?()
             minValueClampedCallback?(self)
         }
-
+        
+        //call press timer on decrement
+        startPressTimer()
         return self
     }
-
+    
     /// Increments the stepper `value` by `incrementStepValue`.
     @discardableResult
     public func incrementValue() -> Self {
+        
         let incrementedValue = (value + incrementStepValue).round(with: roundingBehavior)
-
+        
         // The `value` should wrap to `minimumValue`.
         if wraps && incrementedValue > maximumValue {
             value = minimumValue
-        // The `value` should be incremented.
+            // The `value` should be incremented.
         } else if incrementedValue <= maximumValue {
             value = incrementedValue
             delegate?.KWStepperDidIncrement?()
             incrementCallback?(self)
-        // The `value` should be clamped.
+            // The `value` should be clamped.
         } else {
             endLongPress()
             delegate?.KWStepperMaxValueClamped?()
             maxValueClampedCallback?(self)
         }
-
+        //call press timer on increment
+        startPressTimer()
         return self
     }
+    
+    // start timer to get the stepper after 'autoRepeatInterval'
+    func startPressTimer(){
+        if pressRepeat && pressTimer == nil {
+            pressTimer = Timer.scheduledTimer(
+                timeInterval: pressRepeatInterval,
+                target: self,
+                selector:  #selector(pressTimerAction),
+                userInfo: nil,
+                repeats: true
+            )
+        }
+    }
+    
+    func pressTimerAction(){
+        pressRepeatCallback?(self)
+        pressTimer?.invalidate()
+        pressTimer = nil
+    }
+    
 }
 
 // MARK: - User Interaction
@@ -226,17 +277,17 @@ extension KWStepper {
         guard autoRepeat else {
             return
         }
-
+        
         switch sender.state {
         case .began: startLongPress(sender)
         case .ended, .cancelled, .failed: endLongPress()
         default: break
         }
     }
-
+    
     fileprivate func startLongPress(_ sender: UIGestureRecognizer) {
         guard longPressTimer == nil else { return }
-
+        
         longPressTimer = Timer.scheduledTimer(
             timeInterval: autoRepeatInterval,
             target: self,
@@ -245,7 +296,7 @@ extension KWStepper {
             repeats: true
         )
     }
-
+    
     fileprivate func endLongPress() {
         guard let timer = longPressTimer else { return }
         

--- a/Source/KWStepper.swift
+++ b/Source/KWStepper.swift
@@ -128,9 +128,6 @@ public class KWStepper: UIControl {
             
             sendActions(for: .valueChanged)
             valueChangedCallback?(self)
-            
-            //call press timer on increment
-            startPressTimer()
         }
     }
     
@@ -209,11 +206,13 @@ public class KWStepper: UIControl {
         // The `value` should wrap to `maximumValue`.
         if wraps && decrementedValue < minimumValue {
             value = maximumValue
+            startPressTimer()
             // The `value` should be decremented.
         } else if decrementedValue >= minimumValue {
             value = decrementedValue
             delegate?.KWStepperDidDecrement?()
             decrementCallback?(self)
+            startPressTimer()
             // The `value` should be clamped.
         } else {
             endLongPress()
@@ -233,11 +232,13 @@ public class KWStepper: UIControl {
         // The `value` should wrap to `minimumValue`.
         if wraps && incrementedValue > maximumValue {
             value = minimumValue
+            startPressTimer()
             // The `value` should be incremented.
         } else if incrementedValue <= maximumValue {
             value = incrementedValue
             delegate?.KWStepperDidIncrement?()
             incrementCallback?(self)
+            startPressTimer()
             // The `value` should be clamped.
         } else {
             endLongPress()


### PR DESCRIPTION
if the **pressRepeat == true** there is callback called '**pressRepeatCallback**' after '**autoRepeatInterval**'
this property can used to send stepper value after determined interval to cutting 'value changed' calls