### PR TITLE
Allow subclassing KWStepper

### DIFF
--- a/Source/KWStepper.swift
+++ b/Source/KWStepper.swift
@@ -27,7 +27,7 @@ import UIKit
 
 /// A stepper control with flexible UI and tailored UX.
 
-public class KWStepper: UIControl {
+open class KWStepper: UIControl {
     // MARK: - Configuring the Stepper
 
     /// If true, long pressing repeatedly alters `value`. Default = true.


### PR DESCRIPTION
I wanted to subclass KWStepper in my project so I could encapsulate the specific behavior I needed in my app, but could not because the class was marked “public” and not “open”. For a class to be subclassed outside of its module, Swift requires it to be marked “open”. 